### PR TITLE
[AUD-1109] Fix collectibles gallery scrolling when the details modal is open

### DIFF
--- a/src/components/collectibles/CollectibleDetailsView.module.css
+++ b/src/components/collectibles/CollectibleDetailsView.module.css
@@ -91,7 +91,7 @@
     display: inline-flex;
     gap: 0.5rem;
     position: relative;
-    padding: 10px 16px;
+    padding: 8px 24px;
     background-color: #CC0FE0;
     color: #ffffff;
     font-size: 16px;

--- a/src/components/collectibles/CollectibleGallery.jsx
+++ b/src/components/collectibles/CollectibleGallery.jsx
@@ -53,7 +53,7 @@ const CollectibleGallery = ({
       backgroundColor={backgroundColor}
       className={styles.card}
     >
-      <div className={styles.container}>
+      <div className={cn(styles.container, { [styles.noScroll]: isModalOpen })}>
         <CollectiblesHeader
           user={user}
           backButtonVisible={isModalOpen}

--- a/src/components/collectibles/CollectibleGallery.module.css
+++ b/src/components/collectibles/CollectibleGallery.module.css
@@ -10,6 +10,10 @@
     height: 100%;
 }
 
+.container.noScroll {
+    overflow: hidden;
+}
+
 .collectiblesContainer {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));


### PR DESCRIPTION
[AUD-1109] 

Restrict gallery scrolling when the details modal is open to avoid double scroll bar issue