### PR TITLE
Make collection container full height

### DIFF
--- a/src/components/card/Card.jsx
+++ b/src/components/card/Card.jsx
@@ -70,6 +70,7 @@ const Card = ({
   backgroundColor,
   twitterURL,
   children,
+  fillContainer,
   className
 }) => {
   const [cardStyle, setCardStyle] = useState({})
@@ -89,14 +90,21 @@ const Card = ({
   const { setDimensions } = useContext(CardDimensionsContext)
 
   useEffect(() => {
-    const resizeEventListener = () => {
-      setCardSize(setCardStyle, cardRef, mobileWebTwitter, isTwitter)
-    }
+    if (fillContainer) {
+      setCardStyle({
+        height: '100%',
+        width: '100%'
+      })
+    } else {
+      const resizeEventListener = () => {
+        setCardSize(setCardStyle, cardRef, mobileWebTwitter, isTwitter)
+      }
 
-    resizeEventListener()
-    window.addEventListener('resize', resizeEventListener);
-    return () => {
-      window.removeEventListener('resize', resizeEventListener);
+      resizeEventListener()
+      window.addEventListener('resize', resizeEventListener);
+      return () => {
+        window.removeEventListener('resize', resizeEventListener);
+      }
     }
   }, [setCardSize, setCardStyle, cardRef, mobileWebTwitter, isTwitter])
 

--- a/src/components/collection/CollectionPlayerCard.jsx
+++ b/src/components/collection/CollectionPlayerCard.jsx
@@ -91,6 +91,7 @@ const CollectionPlayerCard = ({
       isTwitter={isTwitter}
       backgroundColor={backgroundColor}
       twitterURL={collection.collectionURLPath}
+      fillContainer
     >
       <div className={styles.padding}>
         <div className={styles.topRow}>


### PR DESCRIPTION
Collections don't need to have aspect ratio height because we are not trying to maintain the aspect ratio of the album artwork

Even currently, twitter looks bad on mobile:
![IMG_2875](https://user-images.githubusercontent.com/2731362/195736749-da5f2683-cac6-404c-ba51-d0c838623091.PNG)

After this change:
<img width="589" alt="Screen Shot 2022-10-13 at 5 29 08 PM" src="https://user-images.githubusercontent.com/2731362/195736770-84933f56-bc6a-43d0-bd8f-3e17f4ab990e.png">

You can still control the embed player via the iframe with this change too:
<img width="1062" alt="Screen Shot 2022-10-13 at 5 43 10 PM" src="https://user-images.githubusercontent.com/2731362/195737007-68e7f42d-9a1a-4ea9-84ce-ebe041ebd507.png">
<img width="1047" alt="Screen Shot 2022-10-13 at 5 42 37 PM" src="https://user-images.githubusercontent.com/2731362/195737008-c3f9a1e3-f12e-410f-8266-5643a2b55657.png">
<img width="1076" alt="Screen Shot 2022-10-13 at 5 42 09 PM" src="https://user-images.githubusercontent.com/2731362/195737009-04455c90-4ff2-4d83-925b-ba1aacf15ce0.png">
<img width="589" alt="Screen Shot 2022-10-13 at 5 29 08 PM" src="https://user-images.githubusercontent.com/2731362/195737012-9e252bc9-ea21-4d03-8a20-1a507908fa23.png">


