### PR TITLE
Fix listen tracking/Amplitude logging due to numeric id -> hash id changes from SDK

### DIFF
--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -38,6 +38,7 @@ const track = (event, properties) => {
   }
 }
 
+/** id param is the numeric id */
 export const recordOpen = (id, title, handle, path) => {
   track(OPEN, { id: `${id}`, handle, title, path, referrer: document.referrer })
 }
@@ -46,6 +47,7 @@ export const recordError = () => {
   track(ERROR, { referrer: document.referrer })
 }
 
+/** id param is the numeric id */
 export const recordPlay = (id) => {
   track(PLAYBACK_PLAY, {
     id: `${id}`,
@@ -54,6 +56,7 @@ export const recordPlay = (id) => {
   })
 }
 
+/** id param is the numeric id */
 export const recordPause = (id) => {
   track(PLAYBACK_PAUSE, {
     id: `${id}`,
@@ -62,6 +65,7 @@ export const recordPause = (id) => {
   })
 }
 
+/** id param is the numeric id */
 export const recordListen = (id) => {
   track(LISTEN, { id: `${id}` })
 }

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -8,6 +8,7 @@ import {
   getTrack,
   getTrackWithHashId
 } from '../util/BedtimeClient'
+import { decodeHashId } from '../util/hashids'
 import CollectiblesPlayerContainer from './collectibles/CollectiblesPlayerContainer'
 import { DEFAULT_DOMINANT_COLOR } from '../util/image/dominantColor.worker'
 import CollectionPlayerContainer from './collection/CollectionPlayerContainer'
@@ -46,7 +47,6 @@ import {
 } from '../routes'
 import { getArtworkUrl } from '../util/getArtworkUrl'
 import { logError } from '../util/logError'
-import { decodeHashId } from '../util/hashids'
 
 if (module.hot) {
   // tslint:disable-next-line:no-var-requires
@@ -213,7 +213,7 @@ const App = (props) => {
           setDid404(false)
           setTracksResponse(track)
           recordOpen(
-            track.id,
+            decodeHashId(track.id),
             track.title,
             track.user.handle,
             stripLeadingSlash(track.permalink)
@@ -249,7 +249,7 @@ const App = (props) => {
           setDid404(false)
           setCollectionsResponse(collection)
           recordOpen(
-            collection.id,
+            decodeHashId(collection.id),
             collection.playlist_name,
             collection.user.handle,
             stripLeadingSlash(collection.permalink)

--- a/src/hooks/usePlayback.js
+++ b/src/hooks/usePlayback.js
@@ -3,6 +3,7 @@ import AudioStream from '../audio/AudioStream'
 import { PlayingState } from '../components/playbutton/PlayButton'
 import { recordPlay, recordPause } from '../analytics/analytics'
 import { sendPostMessage } from '../api/util'
+import { decodeHashId } from '../util/hashids'
 
 const SEEK_INTERVAL = 200
 
@@ -177,7 +178,7 @@ const usePlayback = (id, onAfterAudioEnd) => {
           setPlayingStateRef(PlayingState.Playing)
           audioRef.current?.play()
           setPlayCounter((p) => p + 1)
-          recordPlay(idOverride || id)
+          recordPlay(decodeHashId(idOverride || id))
           sendPostMessage({ event: 'play' })
           break
         case PlayingState.Buffering:
@@ -185,13 +186,13 @@ const usePlayback = (id, onAfterAudioEnd) => {
         case PlayingState.Paused:
           setPlayingStateRef(PlayingState.Playing)
           audioRef.current?.play()
-          recordPlay(idOverride || id)
+          recordPlay(decodeHashId(idOverride || id))
           sendPostMessage({ event: 'play' })
           break
         case PlayingState.Playing:
           setPlayingStateRef(PlayingState.Paused)
           audioRef.current?.pause()
-          recordPause(idOverride || id)
+          recordPause(decodeHashId(idOverride || id))
           sendPostMessage({ event: 'pause' })
           break
       }

--- a/src/hooks/useRecordListens.js
+++ b/src/hooks/useRecordListens.js
@@ -1,11 +1,19 @@
 import { useState } from 'preact/hooks'
 import { recordListen } from '../util/BedtimeClient'
 
-export const useRecordListens = (position, listenId, trackId, listenThresholdSec) => {
+export const useRecordListens = (
+  position,
+  listenId,
+  /** the encoded track id (i.e. the hash id) */
+  trackId,
+  listenThresholdSec
+) => {
   const [lastListenId, setLastListenId] = useState(null)
 
   if (position > listenThresholdSec && listenId !== lastListenId) {
     setLastListenId(listenId)
-    recordListen(trackId)
+    if (trackId != null) {
+      recordListen(trackId)
+    }
   }
 }

--- a/src/util/BedtimeClient.js
+++ b/src/util/BedtimeClient.js
@@ -68,31 +68,10 @@ export const uuid = () => {
   return uuid
 }
 
-// TODO: proptypes
-// export interface TrackResponse {
-//   title: string
-//   handle: string
-//   userName: string
-//   segments: Array<{ duration: number, multihash: string }>
-//   urlPath: string
-// }
-
-// export type GetTracksResponse = TrackResponse & {
-//   isVerified: boolean,
-//   coverArt: string
-// }
-
-// export interface GetCollectionsResponse {
-//     name: string
-//     ownerHandle: string
-//     ownerName: string
-//     collectionURLPath: string
-//     tracks: TrackResponse[]
-//     coverArt: string
-// }
-
+/** param trackId is the encoded track id (i.e. hash id) */
 export const recordListen = async (trackId) => {
-  const url = `${IDENTITY_SERVICE_ENDPOINT}/tracks/${trackId}/listen`
+  const numericHashId = decodeHashId(trackId)
+  const url = `${IDENTITY_SERVICE_ENDPOINT}/tracks/${numericHashId}/listen`
   const method = 'POST'
   const headers = {
     Accept: 'application/json',
@@ -105,7 +84,7 @@ export const recordListen = async (trackId) => {
 
   try {
     await fetch(url, { method, headers, body })
-    recordAnalyticsListen(trackId)
+    recordAnalyticsListen(numericHashId)
   } catch (e) {
     logError(`Got error storing playcount: [${e.message}]`)
   }


### PR DESCRIPTION
Before, GA was returning numeric ids. Now we are using SDK for collections and tracks which returns hash ids. Adjust code for listen tracking + Amplitude metric logging accordingly.