### PR TITLE
Fix collection permalink after SDK v2 upgrade

### DIFF
--- a/src/util/BedtimeClient.js
+++ b/src/util/BedtimeClient.js
@@ -110,7 +110,6 @@ const makeRequest = async (url) => {
 
 const getFormattedCollectionResponse = (collection) => {
   const item = collection?.[0]
-  item.permalink = `${item.permalink ?? ''}-${decodeHashId(item.id)}`
   return item
 }
 


### PR DESCRIPTION
Looks like the permalink field now includes the appended hash id so no need to add it manually anymore